### PR TITLE
Roll numpy back to 1.15

### DIFF
--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -9,7 +9,6 @@ import os
 from typing import Any, Dict, Iterable, List, Optional, SupportsIndex, Tuple, Union, cast
 
 import numpy as np
-from numpy.typing import NDArray
 
 from .alphabet import BPE_CHAR, Alphabet
 from .constants import (
@@ -55,7 +54,6 @@ LMState = Optional[Union[kenlm.State, List[kenlm.State]]]
 OutputBeam = Tuple[str, LMState, List[WordFrames], float, float]
 # for multiprocessing we need to remove kenlm state since it can't be pickled
 OutputBeamMPSafe = Tuple[str, List[WordFrames], float, float]
-NDArrayFloat = NDArray[np.float64]
 
 # constants
 NULL_FRAMES: Frames = (-1, -1)  # placeholder that gets replaced with positive integer frame indices
@@ -82,7 +80,7 @@ def _sum_log_scores(s1: float, s2: float) -> float:
     return log_sum
 
 
-def _log_softmax(x: NDArrayFloat, axis: Optional[int] = None) -> NDArrayFloat:
+def _log_softmax(x: np.ndarray, axis: Optional[int] = None) -> np.ndarray:  #type: ignore [type-arg]
     """Logarithm of softmax function, following implementation of scipy.special."""
     x_max = np.amax(x, axis=axis, keepdims=True)
     if x_max.ndim > 0:
@@ -94,7 +92,7 @@ def _log_softmax(x: NDArrayFloat, axis: Optional[int] = None) -> NDArrayFloat:
     # suppress warnings about log of zero
     with np.errstate(divide="ignore"):
         s = np.sum(exp_tmp, axis=cast(SupportsIndex, axis), keepdims=True)
-        out: NDArrayFloat = np.log(s)
+        out: np.ndarray = np.log(s)  #type: ignore [type-arg]
     out = tmp - out
     return out
 
@@ -306,7 +304,7 @@ class BeamSearchDecoderCTC:
 
     def _decode_logits(
         self,
-        logits: NDArrayFloat,
+        logits: np.ndarray,  #type: ignore [type-arg]
         beam_width: int,
         beam_prune_logp: float,
         token_min_logp: float,
@@ -474,7 +472,7 @@ class BeamSearchDecoderCTC:
 
     def decode_beams(
         self,
-        logits: NDArrayFloat,
+        logits: np.ndarray,  #type: ignore [type-arg]
         beam_width: int = DEFAULT_BEAM_WIDTH,
         beam_prune_logp: float = DEFAULT_PRUNE_LOGP,
         token_min_logp: float = DEFAULT_MIN_TOKEN_LOGP,
@@ -526,7 +524,7 @@ class BeamSearchDecoderCTC:
 
     def _decode_beams_mp_safe(
         self,
-        logits: NDArrayFloat,
+        logits: np.ndarray,  #type: ignore [type-arg]
         beam_width: int,
         beam_prune_logp: float,
         token_min_logp: float,
@@ -554,7 +552,7 @@ class BeamSearchDecoderCTC:
     def decode_beams_batch(
         self,
         pool: Any,
-        logits_list: List[NDArrayFloat],
+        logits_list: List[np.ndarray],  #type: ignore [type-arg]
         beam_width: int = DEFAULT_BEAM_WIDTH,
         beam_prune_logp: float = DEFAULT_PRUNE_LOGP,
         token_min_logp: float = DEFAULT_MIN_TOKEN_LOGP,
@@ -590,7 +588,7 @@ class BeamSearchDecoderCTC:
 
     def decode(
         self,
-        logits: NDArrayFloat,
+        logits: np.ndarray,  #type: ignore [type-arg]
         beam_width: int = DEFAULT_BEAM_WIDTH,
         beam_prune_logp: float = DEFAULT_PRUNE_LOGP,
         token_min_logp: float = DEFAULT_MIN_TOKEN_LOGP,
@@ -627,7 +625,7 @@ class BeamSearchDecoderCTC:
     def decode_batch(
         self,
         pool: Any,
-        logits_list: List[NDArrayFloat],
+        logits_list: List[np.ndarray],  #type: ignore [type-arg]
         beam_width: int = DEFAULT_BEAM_WIDTH,
         beam_prune_logp: float = DEFAULT_PRUNE_LOGP,
         token_min_logp: float = DEFAULT_MIN_TOKEN_LOGP,

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -80,7 +80,10 @@ def _sum_log_scores(s1: float, s2: float) -> float:
     return log_sum
 
 
-def _log_softmax(x: np.ndarray, axis: Optional[int] = None) -> np.ndarray:  #type: ignore [type-arg]
+def _log_softmax(
+    x: np.ndarray,  # type: ignore [type-arg]
+    axis: Optional[int] = None,
+) -> np.ndarray:  # type: ignore [type-arg]
     """Logarithm of softmax function, following implementation of scipy.special."""
     x_max = np.amax(x, axis=axis, keepdims=True)
     if x_max.ndim > 0:
@@ -92,7 +95,7 @@ def _log_softmax(x: np.ndarray, axis: Optional[int] = None) -> np.ndarray:  #typ
     # suppress warnings about log of zero
     with np.errstate(divide="ignore"):
         s = np.sum(exp_tmp, axis=cast(SupportsIndex, axis), keepdims=True)
-        out: np.ndarray = np.log(s)  #type: ignore [type-arg]
+        out: np.ndarray = np.log(s)  # type: ignore [type-arg]
     out = tmp - out
     return out
 
@@ -304,7 +307,7 @@ class BeamSearchDecoderCTC:
 
     def _decode_logits(
         self,
-        logits: np.ndarray,  #type: ignore [type-arg]
+        logits: np.ndarray,  # type: ignore [type-arg]
         beam_width: int,
         beam_prune_logp: float,
         token_min_logp: float,
@@ -472,7 +475,7 @@ class BeamSearchDecoderCTC:
 
     def decode_beams(
         self,
-        logits: np.ndarray,  #type: ignore [type-arg]
+        logits: np.ndarray,  # type: ignore [type-arg]
         beam_width: int = DEFAULT_BEAM_WIDTH,
         beam_prune_logp: float = DEFAULT_PRUNE_LOGP,
         token_min_logp: float = DEFAULT_MIN_TOKEN_LOGP,
@@ -524,7 +527,7 @@ class BeamSearchDecoderCTC:
 
     def _decode_beams_mp_safe(
         self,
-        logits: np.ndarray,  #type: ignore [type-arg]
+        logits: np.ndarray,  # type: ignore [type-arg]
         beam_width: int,
         beam_prune_logp: float,
         token_min_logp: float,
@@ -552,7 +555,7 @@ class BeamSearchDecoderCTC:
     def decode_beams_batch(
         self,
         pool: Any,
-        logits_list: List[np.ndarray],  #type: ignore [type-arg]
+        logits_list: List[np.ndarray],  # type: ignore [type-arg]
         beam_width: int = DEFAULT_BEAM_WIDTH,
         beam_prune_logp: float = DEFAULT_PRUNE_LOGP,
         token_min_logp: float = DEFAULT_MIN_TOKEN_LOGP,
@@ -588,7 +591,7 @@ class BeamSearchDecoderCTC:
 
     def decode(
         self,
-        logits: np.ndarray,  #type: ignore [type-arg]
+        logits: np.ndarray,  # type: ignore [type-arg]
         beam_width: int = DEFAULT_BEAM_WIDTH,
         beam_prune_logp: float = DEFAULT_PRUNE_LOGP,
         token_min_logp: float = DEFAULT_MIN_TOKEN_LOGP,
@@ -625,7 +628,7 @@ class BeamSearchDecoderCTC:
     def decode_batch(
         self,
         pool: Any,
-        logits_list: List[np.ndarray],  #type: ignore [type-arg]
+        logits_list: List[np.ndarray],  # type: ignore [type-arg]
         beam_width: int = DEFAULT_BEAM_WIDTH,
         beam_prune_logp: float = DEFAULT_PRUNE_LOGP,
         token_min_logp: float = DEFAULT_MIN_TOKEN_LOGP,

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def find_long_description() -> str:
 
 # upper limits are untested, not necessarily conflicting
 # lower limits mostly to be python 3 compatible
-REQUIRED_PACKAGES = ["numpy>=1.20.0,<2.0.0", "pygtrie>=2.1,<3.0", "hypothesis>=6.14,<7"]
+REQUIRED_PACKAGES = ["numpy>=1.15.0,<2.0.0", "pygtrie>=2.1,<3.0", "hypothesis>=6.14,<7"]
 
 EXTRAS_REQUIRE = {
     "dev": [


### PR DESCRIPTION
In order to maintain python 3.6 support, roll numpy back to 1.15 and add #type: ignores to np.ndarray annotations so that mypy 0.910 will accept them.