### PR TITLE
fix conversion of ## type bpe format to _ type

### DIFF
--- a/pyctcdecode/alphabet.py
+++ b/pyctcdecode/alphabet.py
@@ -40,6 +40,8 @@ def _convert_bpe_format(token: str) -> str:
         return token
     elif token == "":  # nosec
         return token
+    elif token in ("<unk>", UNK_BPE_CHAR):
+        return token
     else:
         return BPE_CHAR + token
 


### PR DESCRIPTION
Hey,

There was a minor bug in the conversion of ## type bpe format to _ type. Basically, that converts the '<unk>' to '_<unk>', which should not be done. 

Colab notebook demonstrating the issue: https://colab.research.google.com/drive/1Go2_7_ugRx5g0QuyJ4EeCOCdKBtjRLwk?usp=sharing 

Colab notebook demonstrating the fix: https://colab.research.google.com/drive/1oOi6juTD_kBM9Z3h9Uw1C0tcQC_Ga5K5?usp=sharing