### PR TITLE
Fixed the order of argument of decode_batch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Batch support via multiprocessing:
 from multiprocessing import Pool
 
 with Pool() as pool:
-    text_list = decoder.decode_batch(logits_list, pool)
+    text_list = decoder.decode_batch(pool, logits_list)
 ```
 
 Use `pyctcdecode` for a pretrained Conformer-CTC model:


### PR DESCRIPTION
Hi,

The README.md has an example of the function decode_batch:
`text_list = decoder.decode_batch(logits_list, pool)`
but I think it should be
`text_list = decoder.decode_batch(pool, logits_list)`
