### PR TITLE
[Decoder Dir Parsing] Allow decoder folder to contain additional files

### DIFF
--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -700,8 +700,7 @@ class BeamSearchDecoderCTC:
         contents.remove(BeamSearchDecoderCTC._ALPHABET_SERIALIZED_FILENAME)
         lm_directory: Optional[str]
         if contents:
-            lm_directory = contents[0]
-            if lm_directory != BeamSearchDecoderCTC._LANGUAGE_MODEL_SERIALIZED_DIRECTORY:
+            if BeamSearchDecoderCTC._LANGUAGE_MODEL_SERIALIZED_DIRECTORY not in contents:
                 raise ValueError(
                     f"Count not find language model directory. Looking for "
                     f"{BeamSearchDecoderCTC._LANGUAGE_MODEL_SERIALIZED_DIRECTORY}, found {contents}"

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -540,6 +540,7 @@ class TestSerialization(TempfileTestCase):
         good_filenames = [
             ("alphabet.json", "language_model"),
             ("alphabet.json",),
+            ("README.md", "alphabet.json", "language_model"),  # additional file in dir
         ]
         bad_filenames = [
             ("language_model"),  # missing alphabet


### PR DESCRIPTION
This PR slightly relaxed the structure that the decoder is allowed to have. 

**Before this PR**:
The decoder directory essentially can only consist of the `language_model` dir and the `alphabet.json` file. 

**This PR**:
The decoder directory **has to have** a `language_model` dir and a `alphabet.json` file, **but** can also have additional files on the top level. 

I think this goes hand-in-hand with https://github.com/kensho-technologies/pyctcdecode/pull/32#discussion_r758314862 to allow more files in the directory. It would greatly facilitate combining speech model files and decoder files in a "not-too-nested" way (see comment below).