### PR TITLE
Add fork context to multiprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ to perform a hyperparameter optimization study on their own data.)_
 Batch support via multiprocessing:
 
 ``` python
-from multiprocessing import Pool
+import multiprocessing
 
-with Pool() as pool:
+with multiprocessing.get_context("fork").Pool() as pool:
     text_list = decoder.decode_batch(pool, logits_list)
 ```
 

--- a/pyctcdecode/__init__.py
+++ b/pyctcdecode/__init__.py
@@ -5,4 +5,4 @@ from .language_model import LanguageModel  # noqa
 
 
 __package_name__ = "pyctcdecode"
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -257,14 +257,14 @@ class TestDecoder(unittest.TestCase):
 
     def test_decode_batch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.Pool() as pool:
+        with multiprocessing.get_context("fork").Pool() as pool:
             text_list = decoder.decode_batch(pool, [TEST_LOGITS] * 5)
         expected_text_list = ["bugs bunny"] * 5
         self.assertListEqual(expected_text_list, text_list)
 
     def test_decode_beams_batch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.Pool() as pool:
+        with multiprocessing.get_context("fork").Pool() as pool:
             text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
         expected_text_list = [
             [

--- a/tutorials/01_pipeline_nemo.ipynb
+++ b/tutorials/01_pipeline_nemo.ipynb
@@ -362,7 +362,7 @@
    "outputs": [],
    "source": [
     "import multiprocessing\n",
-    "with multiprocessing.Pool() as pool:\n",
+    "with multiprocessing.get_context(\"fork\").Pool() as pool:\n",
     "    pred_list = decoder.decode_batch(pool, logits_list)"
    ]
   },
@@ -547,7 +547,7 @@
     "for a in [0.6, 0.7, 0.8]:\n",
     "    for b in [2.0, 3.0, 4.0]:\n",
     "        decoder.reset_params(alpha=a, beta=b)\n",
-    "        with multiprocessing.Pool(15) as pool:\n",
+    "        with multiprocessing.get_context(\"fork\").Pool(15) as pool:\n",
     "            # use lower beam-with here for fast testing\n",
     "            lm_preds =  decoder.decode_batch(pool, logits_list, beam_width=50)\n",
     "        wer_val = word_error_rate(dev_other_df[\"text\"].tolist(), lm_preds)\n",

--- a/tutorials/03_eval_performance.ipynb
+++ b/tutorials/03_eval_performance.ipynb
@@ -295,7 +295,7 @@
     "for a in [0.6, 0.7, 0.8]:\n",
     "    for b in [2.0, 3.0, 4.0]:\n",
     "        decoder.reset_params(alpha=a, beta=b)\n",
-    "        with multiprocessing.Pool(15) as pool:\n",
+    "        with multiprocessing.get_context(\"fork\").Pool(15) as pool:\n",
     "            # use lower beam-with here for fast testing\n",
     "            lm_preds =  decoder.decode_batch(pool, logits_list, beam_width=50)\n",
     "        wer_val = word_error_rate(dev_other_df[\"text\"].tolist(), lm_preds)\n",
@@ -383,7 +383,7 @@
    "outputs": [],
    "source": [
     "import multiprocessing\n",
-    "with multiprocessing.Pool() as pool:\n",
+    "with multiprocessing.get_context(\"fork\").Pool() as pool:\n",
     "    pred_list = decoder.decode_batch(pool, logits_list)"
    ]
   },
@@ -540,7 +540,7 @@
     "for a in [0.6, 0.7, 0.8]:\n",
     "    for b in [2.0, 3.0, 4.0]:\n",
     "        decoder.reset_params(alpha=a, beta=b)\n",
-    "        with multiprocessing.Pool(15) as pool:\n",
+    "        with multiprocessing.get_context(\"fork\").Pool(15) as pool:\n",
     "            # use lower beam-with here for fast testing\n",
     "            lm_preds =  decoder.decode_batch(pool, logits_list, beam_width=50)\n",
     "        wer_val = word_error_rate(dev_other_df[\"text\"].tolist(), lm_preds)\n",
@@ -572,7 +572,7 @@
     "        beta=3.0,\n",
     "        score_lm_boundary=True,\n",
     "    )\n",
-    "    with multiprocessing.Pool(15) as pool:\n",
+    "    with multiprocessing.get_context(\"fork\").Pool(15) as pool:\n",
     "        pred_list = decoder.decode_batch(logits_list, pool, beam_width=beam_width)\n",
     "    wer_val = eval_average_wer(text_list, pred_list)\n",
     "    t0 = time.time()\n",


### PR DESCRIPTION
on mac with python 3.7+ the default context of multiprocessing changed from fork to spawn, see here: https://stackoverflow.com/questions/64095876/multiprocessing-fork-vs-spawn
to allow access to class variables we need to enforce fork context