### PR TITLE
Mock out flaky CI multicore tests

### DIFF
--- a/pyctcdecode/__init__.py
+++ b/pyctcdecode/__init__.py
@@ -5,4 +5,4 @@ from .language_model import LanguageModel  # noqa
 
 
 __package_name__ = "pyctcdecode"
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -196,9 +196,8 @@ TEST_LOGITS = np.log(np.clip(TEST_PROBS, 1e-15, 1))
 TEST_UNIGRAMS = ["bugs", "bunny"]
 
 
+# Replacement for `multiprocessing.Pool` to get reliable tests that can't crash.
 class MockPool:
-    """Replacement for multiprocessing.Pool to get reliable tests that can't crash."""
-    
     @staticmethod
     def map(func, list_items):
         """Map."""

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -198,6 +198,7 @@ TEST_UNIGRAMS = ["bugs", "bunny"]
 
 class MockPool:
     """Replacement for multiprocessing.Pool to get reliable tests that can't crash."""
+    
     @staticmethod
     def map(func, list_items):
         """Map."""

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -255,59 +255,18 @@ class TestDecoder(unittest.TestCase):
         text = decoder.decode(TEST_LOGITS)
         self.assertEqual(text, "bugs bunny")
 
+    def test_decode_batch(self):
+        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
+        with multiprocessing.get_context("fork").Pool(1) as pool:
+            text_list = decoder.decode_batch(pool, [TEST_LOGITS] * 5)
+        expected_text_list = ["bugs bunny"] * 5
+        self.assertListEqual(expected_text_list, text_list)
+
     def test_logit_shape_mismatch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS)
         wrong_shape_logits = np.hstack([TEST_LOGITS] * 2)
         with self.assertRaises(ValueError):
             _ = decoder.decode(wrong_shape_logits)
-
-    def test_decode_beams_batch(self):
-        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.get_context("fork").Pool(1) as pool:
-            text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
-        expected_text_list = [
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-        ]
-        self.assertListEqual(expected_text_list, text_list)
 
     def test_multi_lm(self):
         alphabet = Alphabet.build_alphabet(SAMPLE_LABELS)

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -255,13 +255,6 @@ class TestDecoder(unittest.TestCase):
         text = decoder.decode(TEST_LOGITS)
         self.assertEqual(text, "bugs bunny")
 
-    def test_decode_batch(self):
-        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.get_context("fork").Pool(1) as pool:
-            text_list = decoder.decode_batch(pool, [TEST_LOGITS] * 5)
-        expected_text_list = ["bugs bunny"] * 5
-        self.assertListEqual(expected_text_list, text_list)
-
     def test_logit_shape_mismatch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS)
         wrong_shape_logits = np.hstack([TEST_LOGITS] * 2)
@@ -269,52 +262,8 @@ class TestDecoder(unittest.TestCase):
             _ = decoder.decode(wrong_shape_logits)
 
     def test_decode_beams_batch(self):
-        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.get_context("fork").Pool(1) as pool:
-            text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
-        expected_text_list = [
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-        ]
-        self.assertListEqual(expected_text_list, text_list)
+        a = multiprocessing.Pool(1)
+        self.assertNotEqual(a, None)
 
     def test_multi_lm(self):
         alphabet = Alphabet.build_alphabet(SAMPLE_LABELS)

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -1,7 +1,6 @@
 # Copyright 2021-present Kensho Technologies, LLC.
 import json
 import math
-import multiprocessing
 import os
 import unittest
 
@@ -198,13 +197,10 @@ TEST_UNIGRAMS = ["bugs", "bunny"]
 
 
 class MockPool:
-    def __init__(self):
-        """init"""
-        pass
-
-    def map(self, f, l):
+    @staticmethod
+    def map(func, list_items):
         """map"""
-        return [f(e) for e in l]
+        return [func(e) for e in list_items]
 
 
 class TestDecoder(unittest.TestCase):

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -268,6 +268,54 @@ class TestDecoder(unittest.TestCase):
         with self.assertRaises(ValueError):
             _ = decoder.decode(wrong_shape_logits)
 
+    def test_decode_beams_batch(self):
+        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
+        with multiprocessing.get_context("fork").Pool(1) as pool:
+            text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
+        expected_text_list = [
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+        ]
+        self.assertListEqual(expected_text_list, text_list)
+
     def test_multi_lm(self):
         alphabet = Alphabet.build_alphabet(SAMPLE_LABELS)
         lm = LanguageModel(TEST_KENLM_MODEL)

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -199,7 +199,7 @@ TEST_UNIGRAMS = ["bugs", "bunny"]
 class MockPool:
     @staticmethod
     def map(func, list_items):
-        """map"""
+        """Map."""
         return [func(e) for e in list_items]
 
 

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -255,69 +255,11 @@ class TestDecoder(unittest.TestCase):
         text = decoder.decode(TEST_LOGITS)
         self.assertEqual(text, "bugs bunny")
 
-    def test_decode_batch(self):
-        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.Pool() as pool:
-            text_list = decoder.decode_batch(pool, [TEST_LOGITS] * 5)
-        expected_text_list = ["bugs bunny"] * 5
-        self.assertListEqual(expected_text_list, text_list)
-
     def test_logit_shape_mismatch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS)
         wrong_shape_logits = np.hstack([TEST_LOGITS] * 2)
         with self.assertRaises(ValueError):
             _ = decoder.decode(wrong_shape_logits)
-        with multiprocessing.Pool() as pool:
-            with self.assertRaises(ValueError):
-                _ = decoder.decode_batch(pool, [wrong_shape_logits] * 5)
-
-    def test_decode_beams_batch(self):
-        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.Pool() as pool:
-            text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
-        expected_text_list = [
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-            [
-                (
-                    "bugs bunny",
-                    [("bugs", (0, 4)), ("bunny", (7, 13))],
-                    -2.853399551509947,
-                    0.14660044849005294,
-                )
-            ],
-        ]
-        self.assertListEqual(expected_text_list, text_list)
 
     def test_multi_lm(self):
         alphabet = Alphabet.build_alphabet(SAMPLE_LABELS)

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -197,6 +197,7 @@ TEST_UNIGRAMS = ["bugs", "bunny"]
 
 
 class MockPool:
+    """Replacement for multiprocessing.Pool to get reliable tests that can't crash."""
     @staticmethod
     def map(func, list_items):
         """Map."""

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -262,8 +262,52 @@ class TestDecoder(unittest.TestCase):
             _ = decoder.decode(wrong_shape_logits)
 
     def test_decode_beams_batch(self):
-        a = multiprocessing.Pool(1)
-        self.assertNotEqual(a, None)
+        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
+        with multiprocessing.get_context("fork").Pool(1) as pool:
+            text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
+        expected_text_list = [
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+        ]
+        self.assertListEqual(expected_text_list, text_list)
 
     def test_multi_lm(self):
         alphabet = Alphabet.build_alphabet(SAMPLE_LABELS)

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -257,7 +257,7 @@ class TestDecoder(unittest.TestCase):
 
     def test_decode_batch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.get_context("fork").Pool(1) as pool:
+        with multiprocessing.Pool() as pool:
             text_list = decoder.decode_batch(pool, [TEST_LOGITS] * 5)
         expected_text_list = ["bugs bunny"] * 5
         self.assertListEqual(expected_text_list, text_list)
@@ -267,13 +267,13 @@ class TestDecoder(unittest.TestCase):
         wrong_shape_logits = np.hstack([TEST_LOGITS] * 2)
         with self.assertRaises(ValueError):
             _ = decoder.decode(wrong_shape_logits)
-        with multiprocessing.get_context("fork").Pool(1) as pool:
+        with multiprocessing.Pool() as pool:
             with self.assertRaises(ValueError):
                 _ = decoder.decode_batch(pool, [wrong_shape_logits] * 5)
 
     def test_decode_beams_batch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.get_context("fork").Pool(1) as pool:
+        with multiprocessing.Pool() as pool:
             text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
         expected_text_list = [
             [

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -1,7 +1,6 @@
 # Copyright 2021-present Kensho Technologies, LLC.
 import json
 import math
-import multiprocessing
 import os
 import unittest
 

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -197,6 +197,16 @@ TEST_LOGITS = np.log(np.clip(TEST_PROBS, 1e-15, 1))
 TEST_UNIGRAMS = ["bugs", "bunny"]
 
 
+class MockPool:
+    def __init__(self):
+        """init"""
+        pass
+
+    def map(self, f, l):
+        """map"""
+        return [f(e) for e in l]
+
+
 class TestDecoder(unittest.TestCase):
     def test_decoder(self):
         alphabet = Alphabet.build_alphabet(SAMPLE_LABELS)
@@ -257,8 +267,8 @@ class TestDecoder(unittest.TestCase):
 
     def test_decode_batch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.get_context("fork").Pool(1) as pool:
-            text_list = decoder.decode_batch(pool, [TEST_LOGITS] * 5)
+        pool = MockPool()
+        text_list = decoder.decode_batch(pool, [TEST_LOGITS] * 5)
         expected_text_list = ["bugs bunny"] * 5
         self.assertListEqual(expected_text_list, text_list)
 
@@ -270,8 +280,8 @@ class TestDecoder(unittest.TestCase):
 
     def test_decode_beams_batch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
-        with multiprocessing.get_context("fork").Pool(1) as pool:
-            text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
+        pool = MockPool()
+        text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
         expected_text_list = [
             [
                 (

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -1,6 +1,7 @@
 # Copyright 2021-present Kensho Technologies, LLC.
 import json
 import math
+import multiprocessing
 import os
 import unittest
 
@@ -254,11 +255,66 @@ class TestDecoder(unittest.TestCase):
         text = decoder.decode(TEST_LOGITS)
         self.assertEqual(text, "bugs bunny")
 
+    def test_decode_batch(self):
+        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
+        with multiprocessing.get_context("fork").Pool(1) as pool:
+            text_list = decoder.decode_batch(pool, [TEST_LOGITS] * 5)
+        expected_text_list = ["bugs bunny"] * 5
+        self.assertListEqual(expected_text_list, text_list)
+
     def test_logit_shape_mismatch(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS)
         wrong_shape_logits = np.hstack([TEST_LOGITS] * 2)
         with self.assertRaises(ValueError):
             _ = decoder.decode(wrong_shape_logits)
+
+    def test_decode_beams_batch(self):
+        decoder = build_ctcdecoder(SAMPLE_LABELS, KENLM_MODEL_PATH, TEST_UNIGRAMS)
+        with multiprocessing.get_context("fork").Pool(1) as pool:
+            text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
+        expected_text_list = [
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+            [
+                (
+                    "bugs bunny",
+                    [("bugs", (0, 4)), ("bunny", (7, 13))],
+                    -2.853399551509947,
+                    0.14660044849005294,
+                )
+            ],
+        ]
+        self.assertListEqual(expected_text_list, text_list)
 
     def test_multi_lm(self):
         alphabet = Alphabet.build_alphabet(SAMPLE_LABELS)


### PR DESCRIPTION
multiprocessing can lead to stalling randomly during CI tests