### PR TITLE
Fixing an issue where windows install fails at least locally due to c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.venv/
 build/
 develop-eggs/
 dist/
@@ -19,6 +20,7 @@ lib64/
 parts/
 sdist/
 var/
+venv/
 wheels/
 *.egg-info/
 .installed.cfg
@@ -43,3 +45,6 @@ coverage.xml
 
 # misc OS
 .DS_Store
+
+# IDE files and directories
+.idea

--- a/pyctcdecode/__init__.py
+++ b/pyctcdecode/__init__.py
@@ -5,4 +5,4 @@ from .language_model import LanguageModel  # noqa
 
 
 __package_name__ = "pyctcdecode"
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -98,7 +98,7 @@ def _log_softmax(
     exp_tmp = np.exp(tmp)
     # suppress warnings about log of zero
     with np.errstate(divide="ignore"):
-        s = np.sum(exp_tmp, axis=axis, keepdims=True)  # type: ignore [type-arg]
+        s = np.sum(exp_tmp, axis=axis, keepdims=True)  # type: ignore [arg-type]
         out: np.ndarray = np.log(s)  # type: ignore [type-arg]
     out = tmp - out
     return out

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -98,7 +98,7 @@ def _log_softmax(
     exp_tmp = np.exp(tmp)
     # suppress warnings about log of zero
     with np.errstate(divide="ignore"):
-        s = np.sum(exp_tmp, axis=axis, keepdims=True)
+        s = np.sum(exp_tmp, axis=axis, keepdims=True)  # type: ignore [type-arg]
         out: np.ndarray = np.log(s)  # type: ignore [type-arg]
     out = tmp - out
     return out

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,15 @@ def read_file(filename: str) -> str:
     here = os.path.abspath(os.path.dirname(__file__))
     if platform.platform().startswith("Windows"):
         # pip local install fails in windows command prompt due to character encoding issue
-        # without this
-        options = {"encoding": "UTF-8"}
-    else:
-        options = {}
+        # without the encoding argument
+        with codecs.open(os.path.join(here, "pyctcdecode", filename, encoding="UTF-8"), "r") as f:
+            file_text = f.read()
 
-    with codecs.open(os.path.join(here, "pyctcdecode", filename), "r", **options) as f:
-        return f.read()
+    else:
+        with codecs.open(os.path.join(here, "pyctcdecode", filename), "r") as f:
+            file_text = f.read()
+
+    return file_text
 
 
 def find_version() -> str:

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import codecs
 import logging
 import os
+import platform
 import re
 
 from setuptools import find_packages, setup  # type: ignore
@@ -15,7 +16,14 @@ def read_file(filename: str) -> str:
     # intentionally *not* adding an encoding option to open, see here:
     # https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
     here = os.path.abspath(os.path.dirname(__file__))
-    with codecs.open(os.path.join(here, "pyctcdecode", filename), "r") as f:
+    if platform.platform().startswith("Windows"):
+        # pip local install fails in windows command prompt due to character encoding issue
+        # without this
+        options = {"encoding": "UTF-8"}
+    else:
+        options = {}
+
+    with codecs.open(os.path.join(here, "pyctcdecode", filename), "r", **options) as f:
         return f.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read_file(filename: str) -> str:
     if platform.platform().startswith("Windows"):
         # pip local install fails in windows command prompt due to character encoding issue
         # without the encoding argument
-        with codecs.open(os.path.join(here, "pyctcdecode", filename, encoding="UTF-8"), "r") as f:
+        with codecs.open(os.path.join(here, "pyctcdecode", filename), "r", encoding="UTF-8") as f:
             file_text = f.read()
 
     else:


### PR DESCRIPTION
Fixing an issue where installation fails on Windows command prompt (at least locally) due to a character encoding error. There may be a better way to do this but it seems to work. Also adding a few things to the .gitignore file.