### PR TITLE
Add some code to bypass multiprocessing when using a spawn context

### DIFF
--- a/pyctcdecode/__init__.py
+++ b/pyctcdecode/__init__.py
@@ -5,4 +5,4 @@ from .language_model import LanguageModel  # noqa
 
 
 __package_name__ = "pyctcdecode"
-__version__ = "0.3.5"
+__version__ = "0.4.0"

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -642,7 +642,7 @@ class BeamSearchDecoderCTC:
             prune_history=prune_history,
             hotword_weight=hotword_weight,
         )
-        decoded_beams_list: List[List[OutputBeamMPSafe]] = pool.map(p_decode, logits_list)
+        decoded_beams_list: List[List[OutputBeamMPSafe]] = valid_pool.map(p_decode, logits_list)
         return decoded_beams_list
 
     def decode(
@@ -730,7 +730,7 @@ class BeamSearchDecoderCTC:
             hotwords=hotwords,
             hotword_weight=hotword_weight,
         )
-        decoded_text_list: List[str] = pool.map(p_decode, logits_list)
+        decoded_text_list: List[str] = valid_pool.map(p_decode, logits_list)
         return decoded_text_list
 
     def save_to_dir(self, filepath: str) -> None:

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -69,7 +69,7 @@ EMPTY_START_BEAM: Beam = ("", "", "", None, [], NULL_FRAMES, 0.0)
 def _get_valid_pool(pool: Optional[Pool]) -> Optional[Pool]:
     """Return the pool if the pool is appropriate for multiprocessing."""
     if pool is None or isinstance(
-        pool._ctx, mp.context.SpawnContext  # pylint: disable=W0212  # type: ignore [attr-defined]
+        pool._ctx, mp.context.SpawnContext  # type: ignore [attr-defined] # pylint: disable=W0212
     ):
         return None
     return pool

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -68,7 +68,9 @@ EMPTY_START_BEAM: Beam = ("", "", "", None, [], NULL_FRAMES, 0.0)
 
 def _get_valid_pool(pool: Optional[Pool]) -> Optional[Pool]:
     """Return the pool if the pool is appropriate for multiprocessing."""
-    if pool is None or isinstance(pool._ctx, mp.context.SpawnContext):  # pylint: disable=W0212
+    if pool is None or isinstance(
+        pool._ctx, mp.context.SpawnContext  # pylint: disable=W0212  # type: ignore [attr-defined]
+    ):
         return None
     return pool
 

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -1,13 +1,13 @@
 # Copyright 2021-present Kensho Technologies, LLC.
 import json
 import math
+from multiprocessing.context import SpawnContext
 import os
 import unittest
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
 import kenlm  # type: ignore
-from multiprocessing.context import SpawnContext
 import numpy as np
 
 from ..alphabet import BPE_TOKEN, UNK_BPE_TOKEN, Alphabet

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -7,6 +7,7 @@ import unittest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 import kenlm  # type: ignore
+from multiprocessing.context import SpawnContext
 import numpy as np
 
 from ..alphabet import BPE_TOKEN, UNK_BPE_TOKEN, Alphabet
@@ -20,7 +21,6 @@ from ..decoder import (
     build_ctcdecoder,
 )
 from ..language_model import LanguageModel, MultiLanguageModel
-from multiprocessing.context import SpawnContext
 from .helpers import TempfileTestCase
 
 

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -200,6 +200,7 @@ TEST_UNIGRAMS = ["bugs", "bunny"]
 # Replacement for `multiprocessing.Pool` to get reliable tests that can't crash.
 class MockPool:
     def __init__(self, ctx):
+        """Fake pool to be able to run map."""
         self._ctx = ctx
         self.map_has_run = False
 


### PR DESCRIPTION
Summary:
Other things I've tried include
- attaching the LM to the instance instead of the class - works but is slow for both fork and spawn since each process rebuilds the LM
- adding the language model as an optional parameter if a spawn context is found and rebuilding the model container - also works, but again is slow since each process needs its own copy 
As far as I can tell this is often going to be faster than the multiprocessing options that I've tried and also allows for just not using a pool at all (new feature for these functions)

This PR also does a bit of refactoring and improving some type hints.