### PR TITLE
Force "utf-8" encoding when reading unigrams

### DIFF
--- a/pyctcdecode/language_model.py
+++ b/pyctcdecode/language_model.py
@@ -373,7 +373,7 @@ class LanguageModel(AbstractLanguageModel):
                 f"but found {json_attrs.keys()}"
             )
 
-        with open(filenames["unigrams"], "r") as fi:
+        with open(filenames["unigrams"], "r",encoding="utf-8") as fi:
             unigrams = fi.read().splitlines()
 
         kenlm_model = kenlm.Model(filenames["kenlm"])


### PR DESCRIPTION
I was getting an "ascii decode" error when running Wav2Vec2 with a language model ([https://huggingface.co/jonatasgrosman/wav2vec2-large-xlsr-53-spanish](https://huggingface.co/jonatasgrosman/wav2vec2-large-xlsr-53-spanish))  in an Apache server. Forcing "utf-8" encoding when reading unigrams solved the problem.