### PR TITLE
Fix bug with scoring with end of statement

### DIFF
--- a/pyctcdecode/__init__.py
+++ b/pyctcdecode/__init__.py
@@ -5,4 +5,4 @@ from .language_model import LanguageModel  # noqa
 
 
 __package_name__ = "pyctcdecode"
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -60,7 +60,7 @@ LMState = Optional[Union["kenlm.State", List["kenlm.State"]]]
 OutputBeam = Tuple[str, LMState, List[WordFrames], float, float]
 # for multiprocessing we need to remove kenlm state since it can't be pickled
 OutputBeamMPSafe = Tuple[str, List[WordFrames], float, float]
-# Key for the languagem model score cache
+# Key for the language model score cache
 # text, is_eos
 LMScoreCacheKey = Tuple[str, bool]
 # LM score with hotword score, raw LM score, LMState

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -316,7 +316,7 @@ class BeamSearchDecoderCTC:
             new_text = _merge_tokens(text, next_word)
             cache_key = (new_text, is_eos)
             if cache_key not in cached_lm_scores:
-                _, prev_raw_lm_score, start_state = cached_lm_scores[cache_key]
+                _, prev_raw_lm_score, start_state = cached_lm_scores[(text, False)]
                 score, end_state = language_model.score(start_state, next_word, is_last_word=is_eos)
                 raw_lm_score = prev_raw_lm_score + score
                 lm_hw_score = raw_lm_score + hotword_scorer.score(new_text)
@@ -512,7 +512,7 @@ class BeamSearchDecoderCTC:
         output_beams = [
             (
                 _normalize_whitespace(text),
-                cached_lm_scores[text][-1] if text in cached_lm_scores else None,
+                cached_lm_scores[(text, True)][-1] if (text, True) in cached_lm_scores else None,
                 list(zip(text.split(), text_frames)),
                 logit_score,
                 combined_score,  # same as logit_score if lm is missing


### PR DESCRIPTION
There is a minor bug where the cache does not check if is_eos is set, so the score for some text can already be set when _get_lm_score with is_eos=True is called. This leads to the score not including any other scoring logic for is_eos=True. This PR makes the LM cache use the text and the value of is_eos in the key to avoid this issue.