### PR TITLE
Change python versions used for testing

### DIFF
--- a/.github/workflows/tests_and_lint.yml
+++ b/.github/workflows/tests_and_lint.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests_and_lint.yml
+++ b/.github/workflows/tests_and_lint.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -660,7 +660,7 @@ class TestSerialization(TempfileTestCase):
     def test_load_from_hub_offline(self):
         import huggingface_hub
 
-        if tuple(huggingface_hub.__version__.split(".")) >= ("0", "8", "0"):
+        if tuple(int(x) for x in huggingface_hub.__version__.split(".")[:3]) >= (0, 8, 0):
             from huggingface_hub.constants import REPO_ID_SEPARATOR
 
             new_hub_structure = True

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -660,7 +660,7 @@ class TestSerialization(TempfileTestCase):
     def test_load_from_hub_offline(self):
         import huggingface_hub
 
-        if huggingface_hub.__version__ >= "0.8.0":
+        if tuple(huggingface_hub.__version__.split(".")) >= ("0", "8", "0"):
             from huggingface_hub.constants import REPO_ID_SEPARATOR
 
             new_hub_structure = True

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -665,7 +665,9 @@ class TestSerialization(TempfileTestCase):
 
             new_hub_structure = True
         else:
-            from huggingface_hub.snapshot_download import REPO_ID_SEPARATOR
+            from huggingface_hub.snapshot_download import (  # pylint: disable=import-error
+                REPO_ID_SEPARATOR,
+            )
 
             new_hub_structure = False
 


### PR DESCRIPTION
Change workflow to run on 3.7-3.10 instead of 3.6-3.9. 3.6 is fully deprecated, 3.7 will lose support soon and is already getting harder to install things.