### PR TITLE
Fix trie prefix order

### DIFF
--- a/pyctcdecode/language_model.py
+++ b/pyctcdecode/language_model.py
@@ -149,7 +149,8 @@ class HotwordScorer:
             )
 
             # create trie for partial word matches
-            char_trie = CharTrie.fromkeys(hotword_unigrams)
+            length_sorted_unigrams = sorted(hotword_unigrams, key=len)
+            char_trie = CharTrie.fromkeys(length_sorted_unigrams)
         else:
             # make an unmatchable pattern
             match_ptn = re.compile(r"^\b$")


### PR DESCRIPTION
We want to find the shortest prefix when doing partial word scoring, so we want to sort the hotwords by length prior to inserting them into a trie