### PR TITLE
Add in ability to load unigrams from arpa file with user-supplied encoding

### DIFF
--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -791,7 +791,9 @@ class BeamSearchDecoderCTC:
         return {"alphabet": alphabet_filepath, "language_model": lm_directory}
 
     @classmethod
-    def load_from_dir(cls, filepath: str) -> "BeamSearchDecoderCTC":
+    def load_from_dir(
+        cls, filepath: str, unigram_encoding: Optional[str] = None
+    ) -> "BeamSearchDecoderCTC":
         """Load a decoder from a directory."""
         filenames = cls.parse_directory_contents(filepath)
         with open(filenames["alphabet"], "r") as fi:  # type: ignore
@@ -799,7 +801,9 @@ class BeamSearchDecoderCTC:
         if filenames["language_model"] is None:
             language_model = None
         else:
-            language_model = LanguageModel.load_from_dir(filenames["language_model"])
+            language_model = LanguageModel.load_from_dir(
+                filenames["language_model"], unigram_encoding=unigram_encoding
+            )
         return cls(alphabet, language_model=language_model)
 
     @classmethod

--- a/pyctcdecode/language_model.py
+++ b/pyctcdecode/language_model.py
@@ -325,7 +325,6 @@ class LanguageModel(AbstractLanguageModel):
             for unigram in sorted(self._unigram_set):
                 fi.write(unigram + "\n")
 
-
         logger.info(
             "copying kenlm model from %s to %s. " "This may take some time",
             self._kenlm_model.path,
@@ -364,7 +363,9 @@ class LanguageModel(AbstractLanguageModel):
         }
 
     @classmethod
-    def load_from_dir(cls, filepath: str, unigram_encoding: Optional[str] = None) -> "LanguageModel":
+    def load_from_dir(
+        cls, filepath: str, unigram_encoding: Optional[str] = None
+    ) -> "LanguageModel":
         """Load from a directory."""
         filenames = cls.parse_directory_contents(filepath)
         with open(filenames["json_attrs"], "r") as fi:

--- a/pyctcdecode/language_model.py
+++ b/pyctcdecode/language_model.py
@@ -310,7 +310,7 @@ class LanguageModel(AbstractLanguageModel):
             json_attrs[attr] = val
         return json_attrs
 
-    def save_to_dir(self, filepath: str) -> None:
+    def save_to_dir(self, filepath: str, unigram_encoding: Optional[str] = None) -> None:
         """Save to a directory."""
         json_attrs = self.serializable_attrs
         json_attr_path = os.path.join(filepath, self._ATTRS_SERIALIZED_FILENAME)
@@ -321,9 +321,10 @@ class LanguageModel(AbstractLanguageModel):
         with open(json_attr_path, "w") as fi:
             json.dump(json_attrs, fi)
 
-        with open(unigrams_path, "w") as fi:
+        with open(unigrams_path, "w", encoding=unigram_encoding) as fi:
             for unigram in sorted(self._unigram_set):
                 fi.write(unigram + "\n")
+
 
         logger.info(
             "copying kenlm model from %s to %s. " "This may take some time",
@@ -363,7 +364,7 @@ class LanguageModel(AbstractLanguageModel):
         }
 
     @classmethod
-    def load_from_dir(cls, filepath: str) -> "LanguageModel":
+    def load_from_dir(cls, filepath: str, unigram_encoding: Optional[str] = None) -> "LanguageModel":
         """Load from a directory."""
         filenames = cls.parse_directory_contents(filepath)
         with open(filenames["json_attrs"], "r") as fi:
@@ -374,7 +375,7 @@ class LanguageModel(AbstractLanguageModel):
                 f"but found {json_attrs.keys()}"
             )
 
-        with open(filenames["unigrams"], "r") as fi:
+        with open(filenames["unigrams"], "r", encoding=unigram_encoding) as fi:
             unigrams = fi.read().splitlines()
 
         kenlm_model = kenlm.Model(filenames["kenlm"])


### PR DESCRIPTION
Add in ability to load unigrams with user-selected encodings. On windows python defaults to non-utf-8 encodings, so the user may need to explicitly load with a utf-8 encoding for this to work properly. Also note that utf-16 is not compatible with kenlm.