### PR TITLE
Change tuples to classes

### DIFF
--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -633,7 +633,7 @@ class BeamSearchDecoderCTC:
             lm_start_state: language model start state for stateful predictions
 
         Returns:
-            List of beams of type OUTPUT_BEAM with various meta information
+            List of beams of type OutputBeam with various meta information
         """
         self._check_logits_dimension(logits)
         # prepare hotword input
@@ -707,7 +707,7 @@ class BeamSearchDecoderCTC:
             hotword_weight: weight factor for hotword importance
 
         Returns:
-            List of list of beams of type OUTPUT_BEAM_MP_SAFE with various meta information
+            List of list of multiprocessing-safe OutputBeams with various meta information
         """
         valid_pool = _get_valid_pool(pool)
         if valid_pool is None:

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -105,10 +105,6 @@ class LMBeam:
     lm_score: float
 
 
-# lm state supports single and multi language model
-LMState = Optional[Union["kenlm.State", List["kenlm.State"]]]
-
-
 @dataclasses.dataclass(frozen=True)
 class OutputBeam:
     """Output information."""

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -1,6 +1,7 @@
 # Copyright 2021-present Kensho Technologies, LLC.
 from __future__ import annotations, division
 
+import dataclasses
 import functools
 import heapq
 import logging
@@ -61,15 +62,38 @@ except ImportError:
 # store frame information for each word, where frame is the logit index of (start_frame, end_frame)
 Frames = Tuple[int, int]
 WordFrames = Tuple[str, Frames]
+
 # all the beam information we need to keep track of during decoding
-# text, next_word, partial_word, last_char, text_frames, part_frames, logit_score
-Beam = Tuple[str, str, str, Optional[str], List[Frames], Frames, float]
-# same as BEAMS but with current lm score that will be discarded again after sorting
-LMBeam = Tuple[str, str, str, Optional[str], List[Frames], Frames, float, float]
+@dataclasses.dataclass(frozen=True)
+class Beam:
+    text: str
+    next_word: str
+    partial_word: str
+    last_char: Optional[str]
+    text_frames: List[Frames]
+    partial_frames: Frames
+    logit_score: float
+
+@dataclasses.dataclass(frozen=True)
+class LMBeam:
+    text: str
+    next_word: str
+    partial_word: str
+    last_char: Optional[str]
+    text_frames: List[Frames]
+    partial_frames: Frames
+    logit_score: float
+    lm_score: float
+
+
 # lm state supports single and multi language model
 LMState = Optional[Union["kenlm.State", List["kenlm.State"]]]
 # for output beams we return the text, the scores, the lm state and the word frame indices
 # text, last_lm_state, text_frames, logit_score, lm_score
+@dataclasses.dataclass(frozen=True)
+class OutputBeam:
+    text: str
+    last_lm_state: LMState
 OutputBeam = Tuple[str, LMState, List[WordFrames], float, float]
 # for multiprocessing we need to remove kenlm state since it can't be pickled
 OutputBeamMPSafe = Tuple[str, List[WordFrames], float, float]

--- a/pyctcdecode/language_model.py
+++ b/pyctcdecode/language_model.py
@@ -37,6 +37,10 @@ except ImportError:
 class AbstractLMState(abc.ABC):
     """Abstract container for state information."""
 
+    def get_mp_safe_state(self) -> Optional["AbstractLMState"]:
+        """Get a multiprocessing-safe version of the state if available."""
+        return None
+
 
 class KenlmState(AbstractLMState):
     def __init__(self, state: "kenlm.State") -> None:

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -15,7 +15,7 @@ from ..decoder import (
     Beam,
     BeamSearchDecoderCTC,
     LMBeam,
-    OutputBeamMPSafe,
+    OutputBeam,
     _merge_beams,
     _normalize_whitespace,
     _prune_history,
@@ -327,40 +327,45 @@ class TestDecoder(unittest.TestCase):
         text_list = decoder.decode_beams_batch(pool, [TEST_LOGITS] * 5)
         expected_text_list = [
             [
-                OutputBeamMPSafe(
+                OutputBeam(
                     "bugs bunny",
+                    None,
                     [("bugs", (0, 4)), ("bunny", (7, 13))],
                     -2.853399551509947,
                     0.14660044849005294,
                 )
             ],
             [
-                OutputBeamMPSafe(
+                OutputBeam(
                     "bugs bunny",
+                    None,
                     [("bugs", (0, 4)), ("bunny", (7, 13))],
                     -2.853399551509947,
                     0.14660044849005294,
                 )
             ],
             [
-                OutputBeamMPSafe(
+                OutputBeam(
                     "bugs bunny",
+                    None,
                     [("bugs", (0, 4)), ("bunny", (7, 13))],
                     -2.853399551509947,
                     0.14660044849005294,
                 )
             ],
             [
-                OutputBeamMPSafe(
+                OutputBeam(
                     "bugs bunny",
+                    None,
                     [("bugs", (0, 4)), ("bunny", (7, 13))],
                     -2.853399551509947,
                     0.14660044849005294,
                 )
             ],
             [
-                OutputBeamMPSafe(
+                OutputBeam(
                     "bugs bunny",
+                    None,
                     [("bugs", (0, 4)), ("bunny", (7, 13))],
                     -2.853399551509947,
                     0.14660044849005294,

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -54,7 +54,8 @@ def _approx_beams(beams, precis=5):
             b.text_frames,
             b.partial_frames,
             round(b.logit_score, precis),
-        ] for b in beams
+        ]
+        for b in beams
     ]
 
 


### PR DESCRIPTION
The beam-related tuples are getting out of hand and are very difficult to use - changing these to dataclasses. Namedtuples might also be an ok option and are likely to be slightly faster when initializing the objects. Hopefully any performance hit won't be noticeable since this is just packaging data in a slightly different way