### PR TITLE
Add partial decoding function for improved streaming functionality

### DIFF
--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -78,6 +78,7 @@ OutputBeamMPSafe = Tuple[str, List[WordFrames], float, float]
 LMScoreCacheKey = Tuple[str, bool]
 # LM score with hotword score, raw LM score, AbstracatLMState
 LMScoreCacheValue = Tuple[float, float, AbstractLMState]
+LMScoreCache = Dict[LMScoreCacheKey, LMScoreCacheValue]
 
 # constants
 NULL_FRAMES: Frames = (-1, -1)  # placeholder that gets replaced with positive integer frame indices
@@ -402,7 +403,7 @@ class BeamSearchDecoderCTC:
         # we can pass in an input start state to keep the decoder stateful and working on realtime
         language_model = self._language_model
         if language_model is None:
-            cached_lm_scores: Dict[LMScoreCacheKey, LMScoreCacheValue] = {}
+            cached_lm_scores: LMScoreCache = {}
         else:
             if lm_start_state is None:
                 start_state = language_model.get_start_state()

--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -434,12 +434,13 @@ class BeamSearchDecoderCTC:
         hotword_scorer: HotwordScorer,
         cached_lm_scores: LMScoreCache,
         cached_p_lm_scores: Dict[str, float],
+        processed_frames: int = 0,
     ) -> List[Beam]:
         """Decode logits for a set of beams with warmed score caches."""
         language_model = self._language_model
         # bpe we can also have trailing word boundaries ▁⁇▁ so we may need to remember breaks
         force_next_break = False
-        for frame_idx, logit_col in enumerate(logits):
+        for frame_idx, logit_col in enumerate(logits, start=processed_frames):
             max_idx = logit_col.argmax()
             idx_list = set(np.where(logit_col >= token_min_logp)[0]) | {max_idx}
             new_beams: List[Beam] = []
@@ -683,6 +684,7 @@ class BeamSearchDecoderCTC:
         cached_lm_scores: LMScoreCache,
         cached_p_lm_scores: Dict[str, float],
         beams: List[Beam],
+        processed_frames: int,
         beam_width: int = DEFAULT_BEAM_WIDTH,
         beam_prune_logp: float = DEFAULT_PRUNE_LOGP,
         token_min_logp: float = DEFAULT_MIN_TOKEN_LOGP,
@@ -711,6 +713,7 @@ class BeamSearchDecoderCTC:
             hotword_scorer,
             cached_lm_scores,
             cached_p_lm_scores,
+            processed_frames=processed_frames,
         )
         trimmed_beams = self._finalize_beams(
             beams,

--- a/pyctcdecode/tests/test_decoder.py
+++ b/pyctcdecode/tests/test_decoder.py
@@ -585,7 +585,7 @@ class TestDecoder(unittest.TestCase):
 
     def test_partial_decode_with_hotwords(self):
         decoder = build_ctcdecoder(SAMPLE_LABELS)
-        hotword_scorer = HotwordScorer.build_scorer(["bugs"],  weight=25.0)
+        hotword_scorer = HotwordScorer.build_scorer(["bugs"], weight=25.0)
         logits1 = TEST_LOGITS[:3]
         logits2 = TEST_LOGITS[3:8]
         logits3 = TEST_LOGITS[8:]


### PR DESCRIPTION
Currently, for streaming, we allow for the user to input a starting LM state. This might work ok in some cases but there are some issues:

We start from an empty beam every time - this is fine if there is not much correlation from chunk to chunk, but for streaming we ideally want a mode where the logits can be split up without affecting the results. So, we need an endpoint where the full beam information is included and the scoring caches are preserved between calls until the user clears them.

The code to use this will be a bit different since the user has to do more management of state objects. An alternate approach would be to save the state within the decoder object so that the user just has to call initialize and clear functions or using kwargs in the partial decode function - I'm not sure what's better here

This issue was pointed out a while ago in an issue but hasn't been addressed yet.