### PR TITLE
Fix potential memory leak issue

### DIFF
--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -309,6 +309,9 @@ class BeamSearchDecoderCTC:
         if lm_score_boundary is not None:
             params["score_boundary"] = lm_score_boundary
         language_model.reset_params(**params)
+    
+    def __del__(self):
+        self.cleanup()
 
     @classmethod
     def clear_class_models(cls) -> None:


### PR DESCRIPTION
The "BeamSearchDecoderCTC" code has potential memory leaks. Even though the decoder object was removed (by calling "__del__" function), memory deallocation may not be achieved neatly, and I have experienced this issue. 
To deallocate memory for the decoder, the cleanup function must be explicitly called. Instead, when the "__del__" function is called, it seems natural to have the cleanup function also called.