### PR TITLE
remove redundant token check

### DIFF
--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -450,14 +450,10 @@ class BeamSearchDecoderCTC:
                 for beam in beams:
                     # if only blank token or same token
                     if char == "" or beam.last_char == char:
-                        if char == "":
-                            new_end_frame = beam.partial_frames[0]
-                        else:
-                            new_end_frame = frame_idx + 1
                         new_part_frames = (
                             beam.partial_frames
                             if char == ""
-                            else (beam.partial_frames[0], new_end_frame)
+                            else (beam.partial_frames[0], frame_idx + 1)
                         )
                         new_beams.append(
                             Beam(


### PR DESCRIPTION
As `new_part_frames` will be assigned with `beam.partial_frames` when `char == ""` and `new_end_frame` wont be used in that case, doing the additional `if char == ""` is redundant and can be removed.  With the removal of the if check, it seemed practical to remove the else block as well and just put the `frame_idx + 1` in the assignment else block.  This eliminates the need for the `new_end_frame` local variable and simplifies this block.