### PR TITLE
Add OutputBeam indexing for backwards compability

### DIFF
--- a/pyctcdecode/decoder.py
+++ b/pyctcdecode/decoder.py
@@ -117,6 +117,21 @@ class OutputBeam:
             last_lm_state = self.last_lm_state.get_mp_safe_state()
         return dataclasses.replace(self, last_lm_state=last_lm_state)
 
+    def __getitem__(self, index: int) -> Any:
+        """Support indexing for backwards compatibility with tuple format."""
+        if index == 0:
+            return self.text
+        elif index == 1:
+            return self.last_lm_state
+        elif index == 2:
+            return self.text_frames
+        elif index == 3:
+            return self.logit_score
+        elif index == 4:
+            return self.lm_score
+        else:
+            raise IndexError(f"OutputBeam index out of range: {index}")
+
 
 # Key for the language model score cache
 # text, is_eos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors =  [
 license = {file = "LICENSE"}
 
 dependencies = [
-    "numpy>=1.15.0,<2.0.0",
+    "numpy>=1.15.0",
     "pygtrie>=2.1,<3.0",
     "importlib-metadata<5;python_version=='3.7'",
 ]


### PR DESCRIPTION
This pull request adds support for tuple-style indexing to the `OutputBeam` class for backwards compatibility. This allows code that previously accessed `OutputBeam` objects as tuples to continue working after recent refactoring.

Backwards compatibility improvements:

* Added a `__getitem__` method to `OutputBeam`, enabling access to its fields by index (e.g., `beam[0]` for `text`, `beam[1]` for `last_lm_state`, etc.), and raising an `IndexError` for invalid indices.

The PR includes support for numpy>=2.0.0 as well.